### PR TITLE
Adding connectors template

### DIFF
--- a/netlify/functions/server/src/schema/template.rs
+++ b/netlify/functions/server/src/schema/template.rs
@@ -9,7 +9,7 @@ pub(crate) struct Template {
     pub(crate) id: ID,
     /// A short, human-readable name for the template.
     name: String,
-    /// An extended description of what the template does.
+    /// Indicates if the template is ready for initialization.
     description: String,
     /// Where the source code for this template can be found, along with a README describing how to use it.
     repo_url: Url,
@@ -30,4 +30,35 @@ pub(crate) enum Language {
     Python,
     Rust,
     Typescript,
+    Graphql
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_template_graphql_language_support() {
+        let json_data = r#"
+        [
+            {
+                "id": "template",
+                "name": "Template",
+                "description": "This is a template",
+                "repo_url": "https://example.com/repo",
+                "download_url": "https://example.com/download",
+                "language": "GRAPHQL"
+            }
+        ]
+        "#;
+
+        let templates: Vec<Template> = serde_json::from_str(json_data)
+            .expect("Failed to parse templates.json into Template structs");
+
+        // Ensure the second template has init_ready is set to true
+        let template = &templates[1];
+        assert_eq!(template.id, ID::from("template"));
+        assert_eq!(template.language, Language::Graphql);
+    }
+}
+

--- a/netlify/functions/server/templates.json
+++ b/netlify/functions/server/templates.json
@@ -64,12 +64,13 @@
     "language": "TYPESCRIPT"
   },
   {
-    "id": "subgraph-csharp-hotchocolate-annotation",
-    "repo_url": "https://github.com/apollographql/subgraph-template-dotnet-hotchocolate-annotation-boilerplate",
-    "download_url": "https://github.com/apollographql/subgraph-template-dotnet-hotchocolate-annotation-boilerplate/archive/refs/heads/main.tar.gz",
-    "description": "For building schema using annotations with the Hot Chocolate framework",
-    "name": "Hot Chocolate (Annotations)",
-    "language": "C_SHARP"
+    "id": "connectors-starter",
+    "repo_url": "https://github.com/apollographql/rover-connectors-starter",
+    "download_url": "https://github.com/apollographql/rover-connectors-starter/archive/refs/heads/main.tar.gz",
+    "description": "A template used by the Rover CLI to initialize an API orchestration project with Apollo Connectors",
+    "name": "Apollo Connectors Starter",
+    "init_ready": true,
+    "language": "GRAPHQL"
   }
 ]
 


### PR DESCRIPTION
### Summary

As part of the new `rover init` command, we aim to reuse the existing `rover template` functionality to support selecting different templates. For milestone one, the main focus is on integrating the GraphQL Connectors template, which is hosted [here](https://github.com/apollographql/rover-connectors-starter).

This PR adds the GraphQL Connectors template under the "Other" category in rover template. The init command will invoke this template directly as part of the "API orchestration" flow, without prompting the user to make a selection.


